### PR TITLE
check if npc name is longer than 20 chars

### DIFF
--- a/Helbreath.HGServerConsole/char/Npc.cpp
+++ b/Helbreath.HGServerConsole/char/Npc.cpp
@@ -89,6 +89,11 @@ bool CNpc::initNpcAttr(char * pNpcName, char cSA)
 	char cTmpName[21];
 	double dV1, dV2, dV3;
 
+	string npcName = pNpcName;
+	if (npcName.length() > 20) {
+		return false;
+	}
+
 	ZeroMemory(cTmpName, sizeof(cTmpName));
 	strcpy(cTmpName, pNpcName);
 


### PR DESCRIPTION
Add validation, if npc name is longer than 20 char then don't allow to create npc

Related to #17 